### PR TITLE
fix: move conditioning to cpu for comfyui conditioning methods

### DIFF
--- a/apply_llm_to_sdxl_adapter.py
+++ b/apply_llm_to_sdxl_adapter.py
@@ -30,6 +30,9 @@ class ApplyLLMToSDXLAdapter:
             with torch.no_grad():
                 conditioning, pooled_output = llm_adapter(llm_hidden_states)
             
+            # Move tensors to CPU for ComfyUI conditioning system
+            conditioning = conditioning.cpu().contiguous()
+            
             # Format conditioning for ComfyUI
             # ComfyUI expects conditioning as a list of [cond_tensor, metadata_dict] tuples
             comfy_conditioning = [[conditioning, {"pooled_output": pooled_output}]]


### PR DESCRIPTION
This pr simply moves the conditioning tensors to CPU to prevent the following error message: `Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument tensors in method wrapper_CUDA_cat)` when using "Conditioning (Concat)" node for example

(This allows for concatenating conditioning from the sdxl adapter and conditioning from the clip text encode node  
Might not be intended usage but hey it works, pretty cool)

I have only tested no conditioning modification (default workflow), conditioning concat and conditioning combine and there didnt seem to be any issue.