### PR TITLE
Fixed t5gemma_text_encoder to use attention mask and added t5gemma_apply_llm_to_sdxl_adapter

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -64,6 +64,9 @@ try:
     from .apply_llm_to_sdxl_adapter import NODE_CLASS_MAPPINGS as ADAPTER_NODE_MAPPINGS
     from .apply_llm_to_sdxl_adapter import NODE_DISPLAY_NAME_MAPPINGS as ADAPTER_NODE_DISPLAY_MAPPINGS
     
+    from .t5gemma_apply_llm_to_sdxl_adapter import NODE_CLASS_MAPPINGS as T5GEMMA_ADAPTER_NODE_MAPPINGS
+    from .t5gemma_apply_llm_to_sdxl_adapter import NODE_DISPLAY_NAME_MAPPINGS as T5GEMMA_ADAPTER_NODE_DISPLAY_MAPPINGS
+    
     logger.info("Successfully imported all node modules from separate files")
     
 except Exception as e:
@@ -84,6 +87,7 @@ all_class_mappings = [
     ADAPTER_LOADER_MAPPINGS,
     ADAPTER_LOADER_CUSTOM_MAPPINGS,
     ADAPTER_NODE_MAPPINGS,
+    T5GEMMA_ADAPTER_NODE_MAPPINGS,
 ]
 
 all_display_mappings = [
@@ -95,6 +99,7 @@ all_display_mappings = [
     ADAPTER_LOADER_DISPLAY_MAPPINGS,
     ADAPTER_LOADER_CUSTOM_DISPLAY_MAPPINGS,
     ADAPTER_NODE_DISPLAY_MAPPINGS,
+    T5GEMMA_ADAPTER_NODE_DISPLAY_MAPPINGS,
 ]
 
 for mapping in all_class_mappings:
@@ -124,6 +129,7 @@ CUSTOM_TYPES = {
     "LLM_TOKENIZER": "Language Model tokenizer instance",
     "LLM_HIDDEN_STATES": "LLM model hidden states",
     "LLM_ADAPTER": "Adapter model instance",
+    "LLM_ATTENTION_MASK": "LLM attention mask",
     "VECTOR_CONDITIONING": "SDXL vector conditioning",
 
 }

--- a/t5gemma_apply_llm_to_sdxl_adapter.py
+++ b/t5gemma_apply_llm_to_sdxl_adapter.py
@@ -1,0 +1,62 @@
+import torch
+import logging
+
+logger = logging.getLogger("LLM-SDXL-Adapter")
+
+class t5gemmaApplyLLMToSDXLAdapter:
+    """
+    ComfyUI node that applies the LLM→SDXL adapter to hidden states to produce SDXL conditioning.
+    Adds pooled_output and optional SDXL size/crop params to the metadata dict.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "llm_hidden_states": ("LLM_HIDDEN_STATES",),
+                "llm_attention_mask": ("LLM_ATTENTION_MASK",),
+                "llm_adapter": ("LLM_ADAPTER",),
+            },
+            "optional": {
+                "width": ("INT", {"default": 1024, "min": 64, "max": 8192, "step": 8}),
+                "height": ("INT", {"default": 1024, "min": 64, "max": 8192, "step": 8}),
+                "target_width": ("INT", {"default": 1024, "min": 64, "max": 8192, "step": 8}),
+                "target_height": ("INT", {"default": 1024, "min": 64, "max": 8192, "step": 8}),
+                "crop_w": ("INT", {"default": 0, "min": 0, "max": 8192}),
+                "crop_h": ("INT", {"default": 0, "min": 0, "max": 8192}),
+            }
+        }
+
+    RETURN_TYPES = ("CONDITIONING",)
+    FUNCTION = "apply"
+    CATEGORY = "llm_sdxl"
+
+    def apply(self, llm_hidden_states, llm_attention_mask, llm_adapter,
+              width=None, height=None, target_width=None, target_height=None, crop_w=None, crop_h=None):
+        try:
+            with torch.no_grad():
+                prompt_embeds, pooled_output = llm_adapter(llm_hidden_states, attention_mask=llm_attention_mask)
+
+            prompt_embeds = prompt_embeds.cpu().contiguous()
+            pooled_output = pooled_output.cpu().contiguous()
+
+            meta = {"pooled_output": pooled_output}
+            if width is not None and height is not None:
+                meta.update({"width": int(width), "height": int(height)})
+            if target_width is not None and target_height is not None:
+                meta.update({"target_width": int(target_width), "target_height": int(target_height)})
+            if crop_w is not None and crop_h is not None:
+                meta.update({"crop_w": int(crop_w), "crop_h": int(crop_h)})
+
+            conditioning = [[prompt_embeds, meta]]
+            return (conditioning,)
+        except Exception as e:
+            logger.error("Failed to apply adapter: %s", str(e))
+            raise
+
+NODE_CLASS_MAPPINGS = {
+    "t5gemmaApplyLLMToSDXLAdapter": t5gemmaApplyLLMToSDXLAdapter
+}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "t5gemmaApplyLLMToSDXLAdapter": "Apply T5Gemma LLM to Adapter"
+}


### PR DESCRIPTION
**t5gemma_text_encoder.py:**
- Changed encode_text function to not use a chat template since T5Gemma doesn't use one.
- Applied attention_mask to inputs of encode_text
- Added custom type LLM_ATTENTION_MASK as a return type
- Added optional parameter to change "max_length". 
**t5gemma_apply_llm_to_sdxl_adapter.py:**
- Added separate apply_llm_to_sdxl_adapter node for t5gemma since it uses an attention mask.
- Added optional parameters
- Also allows for comparison of old code vs new code.
-
**__init__.py:**
- Added mandatory setup code for new node.
- Added custom type  "LLM_ATTENTION_MASK".