### PR TITLE
Align Adapter head_count

### DIFF
--- a/llm_adapter_loader.py
+++ b/llm_adapter_loader.py
@@ -66,7 +66,7 @@ class LLMAdapterLoader:
                 "target_seq_len": 308,
                 "n_wide_blocks": 3,
                 "n_narrow_blocks": 3,
-                "num_heads": 16,
+                "num_heads": 8,
                 "dropout": 0.0,
             },
         }

--- a/llm_adapter_loader.py
+++ b/llm_adapter_loader.py
@@ -56,7 +56,7 @@ class LLMAdapterLoader:
                 "target_seq_len": 308,
                 "n_wide_blocks": 2,
                 "n_narrow_blocks": 3,
-                "num_heads": 16,
+                "num_heads": 4,
                 "dropout": 0.1,
             },
             "t5gemma": {


### PR DESCRIPTION
Currently, the LLMAdapterLoader defaults to num_heads: 16 for T5Gemma-based models. However, the official architecture for T5Gemma-2b-2b-ul utilizes 8 heads.

Using 16 heads causes the cross-attention layers in the adapter to slice the LLM hidden states incorrectly (128-dim vs the intended 256-dim chunks).

Reference: [[Link to config.json for t5gemma-2b-2b-ul-encoder-only]](https://huggingface.co/Minthy/t5gemma-2b-2b-ul2-encoder-only/blob/main/config.json#L52)

Note: If the current adapter weights were trained with 16 heads, they are mathematically misaligned with the base model's logic. This fix is necessary for architectural parity, but will require a re-train of the adapter weights to see the full semantic benefit.
This is further verified by the fact the head dim is 256;
https://huggingface.co/Minthy/t5gemma-2b-2b-ul2-encoder-only/blob/main/config.json#L16