### PR TITLE
Preliminary T5Gemma-2 work

### DIFF
--- a/llm_adapter_loader.py
+++ b/llm_adapter_loader.py
@@ -21,7 +21,7 @@ class LLMAdapterLoader:
     
     @classmethod
     def INPUT_TYPES(cls):
-        adapter_types = ["gemma", "t5gemma"]
+        adapter_types = ["gemma", "t5gemma", "t5gemma-2"]
         return {
             "required": {
                 "adapter_name": (get_llm_adapters(), {
@@ -69,6 +69,16 @@ class LLMAdapterLoader:
                 "num_heads": 16,
                 "dropout": 0.0,
             },
+            "t5gemma-2": {
+                "llm_dim": 2560,            # Verified from config.json
+                "sdxl_seq_dim": 2048,
+                "sdxl_pooled_dim": 1280,
+                "target_seq_len": 308,
+                "n_wide_blocks": 8,         # 4.25 llm layers pr. block - 6 would provide 5.7
+                "n_narrow_blocks": 3,
+                "num_heads": 8,             # Verified from config.json
+                "dropout": 0.0,
+            }
         }
         
         if type not in ADAPTER_PRESETS:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-transformers>=4.53.1
+transformers>=5.3.0
 einops
 safetensors
 torch

--- a/t5gemma_model_loader.py
+++ b/t5gemma_model_loader.py
@@ -1,5 +1,5 @@
 import torch
-from transformers import T5GemmaEncoderModel, AutoTokenizer
+from transformers import T5GemmaEncoderModel, T5Gemma2Model, AutoTokenizer, AutoConfig
 import gc
 import logging
 from .utils import get_llm_checkpoints, get_llm_checkpoint_path
@@ -61,11 +61,21 @@ class T5GEMMALoader:
                 
                 logger.info(f"Loading Language Model from {model_path}")
                 
-                self.model = T5GemmaEncoderModel.from_pretrained(
+                config = AutoConfig.from_pretrained(model_path)
+                
+                if config.model_type == "t5gemma":
+                    model_arch = T5GemmaEncoderModel
+                elif config.model_type == "t5gemma2":
+                    model_arch = T5Gemma2Model
+                else:
+                    raise Exception(f"Unsupported model type: {config.model_type}")
+                
+                self.model = model_arch.from_pretrained(
                     model_path,
                     torch_dtype=torch.bfloat16,
                     device_map=device,
                     is_encoder_decoder=False,
+                    trust_remote_code=True
                 )
                 
                 self.tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
This makes LLM SDXL Adapter compatible with the newer T5Gemma2.

The encoder-only extractions have been done and packaged for this purpose and are on Huggingface.
[270m-encdoer](https://huggingface.co/PhatcatDK/t5gemma-2-270m-270m-encoder-only)
[1b-encoder](https://huggingface.co/PhatcatDK/t5gemma-2-1b-1b-encoder-only)
[4b-encoder](https://huggingface.co/PhatcatDK/t5gemma-2-4b-4b-encoder-only)

Transformers, specifically the T5Gemma2 model implementation, needs to be modified to actually allow for encoder-only models. Currently it is locked as a seq2seq model with tied embeddings and a locked encoder_decoder.
This has been done locally and it's confirmed that semantic tradeoff between t5gemma2 and sdxl is happening; working on a PR to upstream to Transformers.

After that; making the adapter...

At the moment the only adapter that is even remotely compatible is the old gemma3 adapter since it shares mostly the same config values (except head count) with t5gemma-1b-1b.

Expect prompt-following to be non-functional until a dedicated T5Gemma-2 adapter is trained; current testing is limited to verifying the tensor-flow and namespace compatibility.