### PR TITLE
Enable MPS & Memory Hygiene Enhancement

### DIFF
--- a/apply_llm_to_sdxl_adapter.py
+++ b/apply_llm_to_sdxl_adapter.py
@@ -25,13 +25,25 @@ class ApplyLLMToSDXLAdapter:
     def apply_adapter(self, llm_hidden_states, llm_adapter):
         """Apply the LLM to SDXL adapter transformation"""
         try:
+            device = next(llm_adapter.parameters()).device
+            dtype = next(llm_adapter.parameters()).dtype
+            
+            if llm_hidden_states.device != device or llm_hidden_states.dtype != dtype:
+                llm_hidden_states = llm_hidden_states.to(device).to(dtype).contiguous()
+            
             # Apply adapter
             with torch.no_grad():
                 conditioning, pooled_output = llm_adapter(llm_hidden_states)
+                del llm_hidden_states
             
             # Move tensors to CPU for ComfyUI conditioning system
-            conditioning = conditioning.cpu().contiguous()
-            pooled_output = pooled_output.cpu().contiguous()
+            conditioning = conditioning.detach().cpu().contiguous()
+            pooled_output = pooled_output.detach().cpu().contiguous()
+            
+            # Garbage collection
+            gc.collect()
+            if device == "mps":
+                torch.mps.empty_cache()
             
             # Format conditioning for ComfyUI
             # ComfyUI expects conditioning as a list of [cond_tensor, metadata_dict] tuples

--- a/llm_adapter_loader.py
+++ b/llm_adapter_loader.py
@@ -30,7 +30,7 @@ class LLMAdapterLoader:
                 "type": (adapter_types, {"default": "gemma"}),
             },
             "optional": {
-                "device": (["auto", "cuda:0", "cuda:1", "cpu"], {"default": "auto"}),
+                "device": (["auto", "cuda:0", "cuda:1", "mps", "cpu"], {"default": "auto"}),
                 "force_reload": ("BOOLEAN", {"default": False}),
             }
         }
@@ -82,7 +82,10 @@ class LLMAdapterLoader:
                 if self.adapter is not None:
                     del self.adapter
                     gc.collect()
-                    torch.cuda.empty_cache()
+                    if "cuda" in device:
+                        torch.cuda.empty_cache()
+                    if device == "mps":
+                        torch.mps.empty_cache()
                 
                 logger.info(f"Loading LLM to SDXL adapter from {adapter_path}")
                 
@@ -107,7 +110,7 @@ class LLMAdapterLoader:
                     logger.warning(f"Adapter file not found: {adapter_path}, using initialized weights")
                 
                 # Move to device
-                self.adapter.to(device)
+                self.adapter.to(device).to(torch.bfloat16)
                 self.adapter.eval()
                 
                 self.current_adapter_path = adapter_path

--- a/llm_adapter_loader_custom.py
+++ b/llm_adapter_loader_custom.py
@@ -97,7 +97,10 @@ class LLMAdapterLoaderCustom:
                 if self.adapter is not None:
                     del self.adapter
                     gc.collect()
-                    torch.cuda.empty_cache()
+                    if "cuda" in device:
+                        torch.cuda.empty_cache()
+                    if device == "mps":
+                        torch.mps.empty_cache()
                 
                 logger.info(f"Loading LLM to SDXL adapter from {adapter_path}")
                 

--- a/llm_gguf_model_loader.py
+++ b/llm_gguf_model_loader.py
@@ -28,7 +28,7 @@ class LLMGGUFModelLoader:
                 }),
             },
             "optional": {
-                "device": (["auto", "cuda:0", "cuda:1", "cpu"], {
+                "device": (["auto", "cuda:0", "cuda:1", "mps", "cpu"], {
                     "default": "auto"
                 }),
                 "force_reload": ("BOOLEAN", {
@@ -57,7 +57,10 @@ class LLMGGUFModelLoader:
                     del self.model
                     del self.tokenizer
                     gc.collect()
-                    torch.cuda.empty_cache()
+                    if "cuda" in device:
+                        torch.cuda.empty_cache()
+                    if device == "mps":
+                        torch.mps.empty_cache()
                 
                 logger.info(f"Loading Language Model from {model_path}")
                 
@@ -65,10 +68,17 @@ class LLMGGUFModelLoader:
                     model_path,
                     gguf_file = model_name,
                     torch_dtype=torch.bfloat16,
-                    device_map=device,
+                    device_map=None if device == "mps" else device,
                     output_hidden_states=True,
                     trust_remote_code=True
                 )
+
+                if device == "mps":
+                    self.model.to("mps")
+                
+                gc.collect()
+                if device == "mps":
+                    torch.mps.empty_cache()
                 
                 self.tokenizer = AutoTokenizer.from_pretrained(
                     #model_path,

--- a/llm_model_loader.py
+++ b/llm_model_loader.py
@@ -28,7 +28,7 @@ class LLMModelLoader:
                 }),
             },
             "optional": {
-                "device": (["auto", "cuda:0", "cuda:1", "cpu"], {
+                "device": (["auto", "cuda:0", "cuda:1", "mps", "cpu"], {
                     "default": "auto"
                 }),
                 "force_reload": ("BOOLEAN", {
@@ -57,7 +57,10 @@ class LLMModelLoader:
                     del self.model
                     del self.tokenizer
                     gc.collect()
-                    torch.cuda.empty_cache()
+                    if "cuda" in device:
+                        torch.cuda.empty_cache()
+                    if device == "mps":
+                        torch.mps.empty_cache()
                 
                 logger.info(f"Loading Language Model from {model_path}")
                 
@@ -68,6 +71,13 @@ class LLMModelLoader:
                     output_hidden_states=True,
                     trust_remote_code=True
                 )
+                
+                if device == "mps":
+                    self.model.to("mps")
+                
+                gc.collect()
+                if device == "mps":
+                    torch.mps.empty_cache()
                 
                 self.tokenizer = AutoTokenizer.from_pretrained(
                     model_path,

--- a/llm_text_encoder.py
+++ b/llm_text_encoder.py
@@ -75,10 +75,13 @@ class LLMTextEncoder:
             
             # Generate hidden states
             with torch.no_grad():
+                if device == "mps":
+                    torch.mps.synchronize()
                 outputs = model(**inputs)
                 
             # Extract hidden states, skipping first tokens
-            hidden_states = outputs['hidden_states'][-1][:, skip_first:, :].to(torch.float)
+            hidden_states = outputs['hidden_states'][-1][:, skip_first:, :].detach()
+            hidden_states = hidden_states.to(torch.bfloat16).contiguous()
             
             # Prepare info
             info = f"Text: {text[:50]}...\nTokens after skip: {hidden_states.shape[1]}\nShape: {hidden_states.shape}"

--- a/t5gemma_apply_llm_to_sdxl_adapter.py
+++ b/t5gemma_apply_llm_to_sdxl_adapter.py
@@ -1,4 +1,5 @@
 import torch
+import gc
 import logging
 
 logger = logging.getLogger("LLM-SDXL-Adapter")
@@ -34,11 +35,25 @@ class t5gemmaApplyLLMToSDXLAdapter:
     def apply(self, llm_hidden_states, llm_attention_mask, llm_adapter,
               width=None, height=None, target_width=None, target_height=None, crop_w=None, crop_h=None):
         try:
+            device = next(llm_adapter.parameters()).device
+            dtype = next(llm_adapter.parameters()).dtype
+
+            if llm_hidden_states.device != device or llm_hidden_states.dtype != dtype:
+                llm_hidden_states = llm_hidden_states.to(device).to(dtype).contiguous()
+
+            if llm_attention_mask.device != device:
+                llm_attention_mask = llm_attention_mask.to(device).contiguous()
+
             with torch.no_grad():
                 prompt_embeds, pooled_output = llm_adapter(llm_hidden_states, attention_mask=llm_attention_mask)
+                del llm_hidden_states, llm_attention_mask
 
-            prompt_embeds = prompt_embeds.cpu().contiguous()
-            pooled_output = pooled_output.cpu().contiguous()
+            prompt_embeds = prompt_embeds.detach().cpu().contiguous()
+            pooled_output = pooled_output.detach().cpu().contiguous()
+
+            gc.collect()
+            if device == "mps":
+                torch.mps.empty_cache()
 
             meta = {"pooled_output": pooled_output}
             if width is not None and height is not None:

--- a/t5gemma_model_loader.py
+++ b/t5gemma_model_loader.py
@@ -28,7 +28,7 @@ class T5GEMMALoader:
                 }),
             },
             "optional": {
-                "device": (["auto", "cuda:0", "cuda:1", "cpu"], {
+                "device": (["auto", "cuda:0", "cuda:1", "mps", "cpu"], {
                     "default": "auto"
                 }),
                 "force_reload": ("BOOLEAN", {
@@ -57,16 +57,26 @@ class T5GEMMALoader:
                     del self.model
                     del self.tokenizer
                     gc.collect()
-                    torch.cuda.empty_cache()
+                    if "cuda" in device:
+                        torch.cuda.empty_cache()
+                    if device == "mps":
+                        torch.mps.empty_cache()
                 
                 logger.info(f"Loading Language Model from {model_path}")
                 
                 self.model = T5GemmaEncoderModel.from_pretrained(
                     model_path,
                     torch_dtype=torch.bfloat16,
-                    device_map=device,
+                    device_map=None if device == "mps" else device,
                     is_encoder_decoder=False,
                 )
+                
+                if device == "mps":
+                    self.model.to("mps")
+                
+                gc.collect()
+                if device == "mps":
+                    torch.mps.empty_cache()
                 
                 self.tokenizer = AutoTokenizer.from_pretrained(
                     model_path,

--- a/t5gemma_text_encoder.py
+++ b/t5gemma_text_encoder.py
@@ -1,4 +1,5 @@
 import torch
+import gc
 import logging
 
 logger = logging.getLogger("LLM-SDXL-Adapter")
@@ -18,7 +19,7 @@ class T5GEMMATextEncoder:
                 "llm_tokenizer": ("LLM_TOKENIZER",),
                 "text": ("STRING", {"multiline": True, "default": "masterpiece, best quality, 1girl, anime style"}),
                 "max_length": ("INT", {"default": 512, "min": 8, "max": 4096}),
-                "device": (["cpu", "cuda"], {"default": "cuda"}),
+                "device": (["cpu", "mps", "cuda"], {"default": "cuda"}),
                 "dtype": (["float32", "bfloat16"], {"default": "bfloat16"}),
             }
         }
@@ -33,8 +34,11 @@ class T5GEMMATextEncoder:
         Encode text using Language Model and return hidden states
         """
         try:
+            target_device = torch.device(device)
+            target_dtype = torch.bfloat16 if dtype == "bfloat16" else torch.float32
 
-            _ = torch.bfloat16 if dtype == "bfloat16" else torch.float32
+            llm_model.to(target_device).to(target_dtype)
+
             # Tokenize
             inputs = llm_tokenizer(
                 text + "<eos>",
@@ -43,21 +47,31 @@ class T5GEMMATextEncoder:
                 max_length=max_length,
                 truncation=True,
             )
-            input_ids = inputs.input_ids.to(device)
-            attention_mask = inputs.attention_mask.to(device)
+
+            input_ids = inputs.input_ids.to(target_device).contiguous()
+            attention_mask = inputs.attention_mask.to(target_device).contiguous()
 
             # Generate hidden states
             with torch.no_grad():
+                if device == "mps":
+                    torch.mps.synchronize()
+
                 outputs = llm_model(input_ids=input_ids, attention_mask=attention_mask)
                 # Extract hidden states
-                hidden_states = outputs.last_hidden_state.to(torch.float32)
-                
+                hidden_states = outputs.last_hidden_state.detach().contiguous()
+
+            del input_ids, outputs
+
+            gc.collect()
+            if device == "mps":
+                torch.mps.empty_cache()
+            
             # Prepare info
             info = f"Text: {text[:50]}...\nEncoded: {hidden_states.shape[1]}\nShape: {hidden_states.shape}"
             
             logger.info(f"Encoded text with shape: {hidden_states.shape}")
             
-            return (hidden_states, attention_mask, info)
+            return (hidden_states, attention_mask.to(torch.int), info)
         except Exception as e:
             logger.error(f"Failed to encode text: {str(e)}")
             raise Exception(f"Text encoding failed: {str(e)}")


### PR DESCRIPTION
Implement MPS:

This change is crucial for users on Apple Silicon. Native BF16 execution on MPS is required to prevent the "smoothing" artifacts caused by CPU upcasting. When BF16 tensors (7-bit mantissa) are upcast to FP32 (23-bit mantissa) on the CPU, the bit-depth expansion acts as a mathematical low-pass filter. Because the coarse BF16 grid does not align perfectly with the finer FP32 grid, the resulting interpolation "smears" the micro-contrast between adjacent pixels. This numerical drift leads to a loss of high-frequency spatial data, turning sharp textures like individual hair strands into "clumped" or "cartoonish" shapes.

By maintaining quantization integrity through native BF16 execution on the GPU, we preserve the original "stepped" transitions of the model weights, ensuring fine details remain distinct.

Example images generated with Rouwei 0.8 VPred using the T5Gemma adapter;

CPU:
<img width="448" height="576" alt="ComfyUI_T5G_00001_" src="https://github.com/user-attachments/assets/b2fab0cc-a257-43da-a5b6-2b9347d68a04" />

MPS:
<img width="448" height="576" alt="ComfyUI_T5G_00002_" src="https://github.com/user-attachments/assets/d4f895f9-3ba1-410b-916a-fcc117eda404" />

Other changes:

- Added torch.mps.synchronize() before LLM inference to prevent race conditions on Unified Memory.

- Implemented del on large intermediate tensors (like the full T5/Gemma outputs object) immediately after extracting required hidden states.

- Added torch.mps.empty_cache() and gc.collect() triggers to ensure the memory footprint stays low on consumer grade hardware.

- Set device_map=None for MPS to prevent inefficient model splitting across CPU/GPU.

- Converted attention masks to torch.int for better downstream compatibility with SDXL adapters.


Known Issue: MPS "Cold Start" Latency
Apple Silicon may hang or crawl during initial MPS generations due to Metal "Lazy Loading" triggering a swap storm. Initializing the model on the CPU forces the weights into the Active/Wired memory state. Even a partial CPU run (cancelled after the first step) is sufficient to "Warm" the Unified Memory, allowing subsequent MPS generations to bypass I/O-related stalls and hit the baseline speed almost immediately.